### PR TITLE
Updated .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,10 @@ COMPOSE_PROJECT_NAME=new-site
 #
 # Network name
 # 
-# Your container app must use a network conencted to your webproxy 
-# https://github.com/evertramos/docker-compose-letsencrypt-nginx-proxy-companion
-#
-NETWORK=webproxy
+# Your container app must use a network connected to your webproxy 
+# https://github.com/evertramos/nginx-proxy-automation
+# The default network name has been renamed to "proxy". It no longer is "webproxy"
+NETWORK=proxy
 
 #
 # Database Container options


### PR DESCRIPTION
The default network name has been renamed to "proxy".
Before it was "webproxy".