### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,10 @@ COMPOSE_PROJECT_NAME=new-site
 #
 # Network name
 # 
-# Your container app must use a network conencted to your webproxy 
-# https://github.com/evertramos/docker-compose-letsencrypt-nginx-proxy-companion
-#
-NETWORK=webproxy
+# Your container app must use a network connected to your webproxy 
+# https://github.com/evertramos/nginx-proxy-automation
+# The default network name is "proxy"
+NETWORK=proxy
 
 #
 # Database Container options


### PR DESCRIPTION
The default network name "webproxy" has been renamed to "proxy" in the https://github.com/evertramos/nginx-proxy-automation repository.